### PR TITLE
Tree-sitter Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,8 @@ dependencies = [
  "scylla",
  "tokio",
  "tower-lsp",
+ "tree-sitter",
+ "tttx-tree-sitter-cql",
 ]
 
 [[package]]
@@ -245,7 +247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -297,6 +299,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fern"
@@ -449,6 +457,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "httparse"
@@ -623,6 +637,16 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -1038,7 +1062,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures",
- "hashbrown",
+ "hashbrown 0.14.5",
  "itertools",
  "lazy_static",
  "lz4_flex",
@@ -1127,6 +1151,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -1201,6 +1226,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -1410,6 +1441,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ac5ea5e7f2f1700842ec071401010b9c59bf735295f6e9fa079c3dc035b167"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tttx-tree-sitter-cql"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37f5b12d428b5e843c2fce6893c442669eb4b7b2298ed71b1150171bbffaa7f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ regex = "1.11.1"
 scylla = { version = "1.1.0", features = ["full-serialization"] }
 tokio = { version = "1.44.2", features = ["full"] }
 tower-lsp = "0.20.0"
+tree-sitter = "0.25.3"
+tttx-tree-sitter-cql = "0.1.0"
 
 [lib]
 path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod consts;
 pub mod cqlsh;
 pub mod lsp;
 pub mod setup;
+pub mod tree_sitter;

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -1,0 +1,11 @@
+use once_cell::sync::Lazy;
+use tokio::sync::Mutex;
+use tree_sitter::{Node, Parser, TreeCursor};
+
+pub static TS_CQL: Lazy<Mutex<Parser>> = Lazy::new(|| {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tttx_tree_sitter_cql::LANGUAGE.into())
+        .expect("Error loading CQL grammar");
+    Mutex::new(parser)
+});


### PR DESCRIPTION
Update Cargo.toml, added 2 new dependencies: tree-sitter && tttx-tree-sitter-cql. tree_sitter.rs. Implemented basic tree-sitter init logic. Add tree-sitter to lib.rs.